### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/frontend/src/components/layouts/PageHeader.tsx
+++ b/frontend/src/components/layouts/PageHeader.tsx
@@ -16,7 +16,12 @@ export function PageHeader({
   className,
 }: PageHeaderProps) {
   return (
-    <div className={cn("flex items-center justify-between pb-6", className)}>
+    <div
+      className={cn(
+        "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between pb-6",
+        className,
+      )}
+    >
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
         {description && (


### PR DESCRIPTION
## Summary
- tweak viewport meta for iOS safe-area support
- make `PageHeader` layout responsive on small screens

## Testing
- `pnpm lint`
- `pnpm build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68411207aac08323beac42e1637ca8c6